### PR TITLE
Optimize fruit-list call

### DIFF
--- a/src/blog/migrations/0002_added_indexes.py
+++ b/src/blog/migrations/0002_added_indexes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blog', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='blogpost',
+            name='created',
+            field=models.DateTimeField(db_index=True, verbose_name='created', default=django.utils.timezone.now, editable=False),
+        ),
+    ]

--- a/src/comments/migrations/0003_added_indexes.py
+++ b/src/comments/migrations/0003_added_indexes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('comments', '0002_comment_complaint'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='comment',
+            name='created',
+            field=models.DateTimeField(default=django.utils.timezone.now, db_index=True, editable=False, verbose_name='created'),
+        ),
+    ]

--- a/src/fruit/api/serializers.py
+++ b/src/fruit/api/serializers.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from rest_framework import serializers
 
 from user.api.serializers import UserSerializer
@@ -39,13 +40,19 @@ class VerboseFruitSerializer(serializers.HyperlinkedModelSerializer):
         read_only=True,
     )
 
-    url = serializers.HyperlinkedIdentityField(view_name='api:fruit-detail')
+    # do not use HyperlinkedModelSerializer because of slowness
+    url = serializers.SerializerMethodField()
 
     user = UserSerializer(read_only=True)
 
     images_count = serializers.IntegerField(read_only=True)
 
     images = HyperlinkedGalleryField(gallery_ct='fruit')
+
+    def get_url(self, obj):
+        if not hasattr(self, '_cached_url'):
+            self._cached_url = self.context['request'].build_absolute_uri(reverse('api:fruit-detail', args=(obj.pk,)))
+        return self._cached_url
 
     class Meta:
         model = Fruit

--- a/src/fruit/migrations/0003_added_indexes.py
+++ b/src/fruit/migrations/0003_added_indexes.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fruit', '0002_fruit_cover_image'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fruit',
+            name='created',
+            field=models.DateTimeField(verbose_name='created', db_index=True, editable=False, default=django.utils.timezone.now),
+        ),
+        migrations.AlterField(
+            model_name='fruit',
+            name='deleted',
+            field=models.BooleanField(verbose_name='deleted', db_index=True, default=False),
+        ),
+    ]

--- a/src/fruit/models.py
+++ b/src/fruit/models.py
@@ -83,7 +83,7 @@ class Fruit(TimeStampedModel, GalleryModel):
                     'as you find relevant.')
     )
 
-    deleted = models.BooleanField(_('deleted'), default=False)
+    deleted = models.BooleanField(_('deleted'), default=False, db_index=True)
     why_deleted = models.TextField(
         _('why deleted'),
         blank=True,

--- a/src/gallery/migrations/0003_added_indexes.py
+++ b/src/gallery/migrations/0003_added_indexes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gallery', '0002_image_author'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='image',
+            name='created',
+            field=models.DateTimeField(db_index=True, verbose_name='created', editable=False, default=django.utils.timezone.now),
+        ),
+    ]

--- a/src/user/migrations/0004_added_indexes.py
+++ b/src/user/migrations/0004_added_indexes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user', '0003_alter_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='message',
+            name='created',
+            field=models.DateTimeField(default=django.utils.timezone.now, verbose_name='created', db_index=True, editable=False),
+        ),
+    ]

--- a/src/utils/models.py
+++ b/src/utils/models.py
@@ -10,7 +10,7 @@ class TimeStampedModel(models.Model):
     An abstract base class model that provides self-managed timezone-aware
     "created" and "modified" fields.
     """
-    created = models.DateTimeField(_('created'), default=timezone.now, editable=False)
+    created = models.DateTimeField(_('created'), default=timezone.now, editable=False, db_index=True)
     modified = AutoDateTimeField(_('modified'), default=timezone.now, editable=False)
 
     class Meta:


### PR DESCRIPTION
I managed to optimize `/api/v1/fruit/` call from ~4 sec to ~1.5 sec. One improvement is that I added indexes to `Fruit.deleted` and on common field `TimeStampModel.created` so PostgreSQL now can use indexes to cover this query. 
Second change is replaced serializers HylerlinkedIdentityField by custom method with cached URL, because it was slowing serializing a lot.

First change didn't do much to optimize performance, but I think to add these indexes wouldn't hurt. Second change helped to speed up call a lot, but the code itself could need some tuning.

Either way there should be added some caching with invalidation on Fruit model change.
