### PR TITLE
Second try to optimized performance of fruit API call

### DIFF
--- a/src/utils/serializer_fields.py
+++ b/src/utils/serializer_fields.py
@@ -1,0 +1,32 @@
+import sys
+
+from rest_framework.serializers import HyperlinkedIdentityField
+
+# used to cache URLS in CachedHyperlinkedIdentityField
+URL_CACHE = {}
+
+
+class CachedHyperlinkedIdentityField(HyperlinkedIdentityField):
+    """
+    This is a performance wrapper for HyperlinkedIdentityField.
+    We save a ton of time by pre-computing the URL the first time it's
+    accessed, to save calling reverse potentially thousands of times
+    per request.
+    """
+    ID_TOKEN = str(sys.maxsize)
+
+    def to_representation(self, value):
+        global URL_CACHE
+        try:
+            url = URL_CACHE[self.view_name]
+        except KeyError:
+            real_id = value.id
+            value.id = self.ID_TOKEN
+            url = super(CachedHyperlinkedIdentityField, self).to_representation(value)
+            URL_CACHE[self.view_name] = url
+            value.id = real_id
+        return url.replace(self.ID_TOKEN, str(value.id))
+
+
+
+


### PR DESCRIPTION
Instead of caching output of `reverse` I just generate fruit detail URL with placeholder ID and then replace this ID with current fruit ID. Still not too pretty, but it's great speed improvement. And it's working this time :)
