### PR TITLE
Fixed map icon magnifying glass on android browser

### DIFF
--- a/src/naovoce/static/less/naovoce.less
+++ b/src/naovoce/static/less/naovoce.less
@@ -509,7 +509,7 @@ a.read-more {
 	}
 	.geocoder-control-input {
 		background-image: url("@{base-url}/img/search.svg");
-		background-size: 17px;
+		background-size: 17px !important;
 		background-position: right 5px top 5px;
 	}
 }


### PR DESCRIPTION
I found out that android browser is not overriding CSS rules properly, so I boosted it with `!important`. Not best solution maybe, but it does the job :)
Tested on my ASUS ZenFone 2 with Android 5.0.1 on chrome and opera browser.
Fixes #15 
