### PR TITLE
fix zooming to detail

### DIFF
--- a/src/naovoce/templates/inc/mapjs.html
+++ b/src/naovoce/templates/inc/mapjs.html
@@ -163,8 +163,7 @@
 			@
 
 		focusTo: (latlng) ->
-			@setView latlng
-			@setZoom 10
+			@setView latlng, 10
 			@
 
 		fetchAddress: (latlng, onSuccess) ->


### PR DESCRIPTION
Na lokálu mi nefungoval detail místa. Pravděpodobná příčina je ta, že když se nastavuje poloha, tak má mapa ještě nastavený nějaký nesmyslný zoomlevel. Oprava je ta, že se funkcí `setView` nastaví zoomlevel s pozicí najednou.

Divné je, že na webu to funguje dobře, ale možná je tam nějaká jiná verze Leafletu, nebo něco.