### PR TITLE
requirements.txt: django-allauth no longer supports Django ~1.8

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,6 @@
 Pillow>=3
 CairoSVG>=1.0
-django-allauth>=0.23
+django-allauth>=0.23,<=0.34
 django-bootstrap-form>=3.2
 django-compressor>=1.5
 django-ipware>=1.1


### PR DESCRIPTION
- https://github.com/pennersr/django-allauth/commit/cfc5112bf474af2cbb16e4b4a36708e8949a2105